### PR TITLE
Better transform and texture handling

### DIFF
--- a/converter/gltf_to_tileset.py
+++ b/converter/gltf_to_tileset.py
@@ -72,7 +72,7 @@ def gltf_to_tileset(fin, fout, measure: Measure = Measure.METER):
     gltf, buffer = io.read_gltf(fin)
     Path(fout).parent.mkdir(parents=True, exist_ok=True)
     gltf_slicer = Slicer(gltf, buffer=buffer)
-    Tile.measure = Measure.FOOT
+    Tile.measure = measure
     tiles = list(map(lambda id: Tile(content_id=id, instance_box=gltf_slicer.get_bounding_box(
         id), instances_matrices=gltf_slicer.get_matrices(id), matrix=Matrix4(), gltf=gltf_slicer.slice_mesh(id).as_bytes(), extras=gltf_slicer.get_extras(id)), range(gltf_slicer.meshes_count)))
     tiles.sort(key=lambda tile: tile.box_world.diagonal)

--- a/tileset/tile.py
+++ b/tileset/tile.py
@@ -111,9 +111,9 @@ class Tile:
             return max(list(map(lambda tile: tile.geometric_error, self.__children)))
 
         if Tile.measure is Measure.FOOT:
-            return self.__instance_box.diagonal * FOOT_TO_METER_MULTIPLIER
+            return self.box_world.diagonal * FOOT_TO_METER_MULTIPLIER
 
-        return self.__instance_box.diagonal
+        return self.box_world.diagonal
 
     @ property
     def dict(self):

--- a/utils/matrix.py
+++ b/utils/matrix.py
@@ -51,6 +51,42 @@ class Matrix4:
 
         return [sx, sy, sz]
 
+    def scaleBy(self, s):
+        self.__matrix[0,0] *= s[0];
+        self.__matrix[0,1] *= s[1];
+        self.__matrix[0,2] *= s[2];
+        self.__matrix[1,0] *= s[0];
+        self.__matrix[1,1] *= s[1];
+        self.__matrix[1,2] *= s[2];
+        self.__matrix[2,0] *= s[0];
+        self.__matrix[2,1] *= s[1];
+        self.__matrix[2,2] *= s[2];
+        return self
+
+    def translateBy(self, t):
+        self.__matrix[0,3] += t[0];
+        self.__matrix[1,3] += t[1];
+        self.__matrix[2,3] += t[2];
+        return self
+
+    def rotateBy(self, q):
+        x2 = 2*q[0]*q[0]
+        y2 = 2*q[1]*q[1]
+        z2 = 2*q[2]*q[2]
+        xy = 2*q[0]*q[1]
+        xz = 2*q[0]*q[2]
+        yz = 2*q[1]*q[2]
+        xw = 2*q[0]*q[3]
+        yw = 2*q[1]*q[3]
+        zw = 2*q[2]*q[3]
+        mul = Matrix4([
+            1-y2-z2, xy-zw, xz+yw, 0,
+            xy+zw, 1-x2-z2, yz-xw, 0,
+            xz-yw, yz+xw, 1-x2-y2, 0,
+            0, 0, 0, 1
+        ])
+        return self.multiply(mul)
+
     def clone(self):
         return Matrix4(self.__matrix)
 


### PR DESCRIPTION
* Apply translation/rotation/scale if present (and matrix is not).
* Calculate geometricError on the transformed box, to handle scaling correctly.
* Fix a couple of bugs in the handling of textures: textures[i].source does not necessarily point to images[i], and samplers were not being copied across to the glbm.
* Fix handling of metres vs feet.