### PR TITLE
Handle multiple buffers correctly

### DIFF
--- a/converter/gltf_to_tileset.py
+++ b/converter/gltf_to_tileset.py
@@ -72,9 +72,9 @@ def split_group(source):
 
 def gltf_to_tileset(fin, fout, measure: Measure = Measure.METER, up_direction: Axis = Axis.Y):
     Gltf.up_direction = up_direction
-    gltf, buffer = io.read_gltf(fin)
+    gltf, buffers = io.read_gltf(fin)
     Path(fout).parent.mkdir(parents=True, exist_ok=True)
-    gltf_slicer = Slicer(gltf, buffer=buffer)
+    gltf_slicer = Slicer(gltf, buffers=buffers)
     Tile.measure = measure
     tiles = list(map(lambda id: Tile(content_id=id, instance_box=gltf_slicer.get_bounding_box(
         id), instances_matrices=gltf_slicer.get_matrices(id), matrix=Matrix4(), gltf=gltf_slicer.slice_mesh(id).as_bytes(), extras=gltf_slicer.get_extras(id)), range(gltf_slicer.meshes_count)))

--- a/gltf/io.py
+++ b/gltf/io.py
@@ -13,14 +13,11 @@ def read_gltf(fin):
     with open(fin, encoding='utf-8') as f:
         gltf = json.load(f, object_hook=lambda d: Element(**d))
 
-    # buffers = []
-    # for buffer in gltf.buffers:
-    #     buffers.append(read_buffer(buffer.uri))
-    # with open(Path(fin).parent / gltf.buffers[0].uri, "rb") as f:
-    #     buffer = f.read()
-    buffer = read_buffer(gltf.buffers[0].uri, Path(fin).parent)
+    buffers = []
+    for buffer in gltf.buffers:
+        buffers.append(read_buffer(buffer.uri, Path(fin).parent))
 
-    return gltf, buffer
+    return gltf, buffers
 
 
 def read_buffer(uri, parent):

--- a/main.py
+++ b/main.py
@@ -44,12 +44,12 @@ def glb(
         help="Optional output glb path (defaults to the path of the input file)"
             )):
     """convert gltf to glb"""
-    gltf, buffer = io.read_gltf(fin)
+    gltf, buffers = io.read_gltf(fin)
 
     if not fout:
         fout = Path(fin).with_suffix(".glb")
     with open(fout, "wb") as f:
-        f.write(Glb(buffer, **gltf.as_dict(False)).as_bytes())
+        f.write(Glb(buffers, **gltf.as_dict(False)).as_bytes())
     io.copy_textures(fin, fout, gltf.images)
     typer.echo("completed")
 
@@ -63,7 +63,7 @@ def b3dm(
         help="Optional output b3dm path(defaults to the path of the input file)"
             )):
     """convert gltf to b3dm"""
-    gltf, buffer = io.read_gltf(fin)
+    gltf, buffers = io.read_gltf(fin)
 
     if not fout:
         fout = Path(fin).with_suffix(".b3dm")
@@ -71,7 +71,7 @@ def b3dm(
     with open(fout, "wb") as f:
         f.write(
             B3dm("b3dm",
-                 Glb(buffer, **gltf.as_dict(False)).as_bytes()).as_bytes())
+                 Glb(buffers, **gltf.as_dict(False)).as_bytes()).as_bytes())
     io.copy_textures(fin, fout, gltf.images)
     typer.echo("completed")
 

--- a/tileset/content.py
+++ b/tileset/content.py
@@ -47,6 +47,9 @@ class Content(ABC):
     def _header_len(self):
         pass
 
+    def _byte_len(self):
+        return self._header_len() + self._feature_json_len() + len(self._feature_bin()) + self._batch_json_len() + len(self.content)
+
     def _header(self) -> bytes:
         ret = bytearray(self._magic())
         ret += utils.int_to_bytes(Content.VERSION)
@@ -55,8 +58,7 @@ class Content(ABC):
         feature_bytes = self._feature_bin()
         feature_bytes_len = len(feature_bytes)
         batch_json_len = self._batch_json_len()
-        ret += utils.int_to_bytes(self._header_len() +
-                                  feature_json_len + feature_bytes_len + batch_json_len + len(self.content))
+        ret += utils.int_to_bytes(utils.padded_len(self._byte_len()))
         ret += utils.int_to_bytes(feature_json_len)
         ret += utils.int_to_bytes(feature_bytes_len)
         ret += utils.int_to_bytes(batch_json_len)
@@ -74,6 +76,9 @@ class Content(ABC):
         ret += feature_bytes
         ret += bytearray(self._batch_json().ljust(self._batch_json_len(), b' '))
         ret += self.content
+        byteLen = self._byte_len()
+        padding = utils.padded_len(byteLen) - byteLen
+        ret += b'\0' * padding
         return ret
 
     @abstractmethod


### PR DESCRIPTION
Handle the case where a glTF file has multiple buffers. This has the nice effect of reducing memory usage and tile size considerably, if you create a glTF with one buffer per mesh or per bufferView.

There are also some fixes for buffer alignment. Tilesets are now _almost_ clean if you run them through CesiumGS/3d-tiles-validator. (And by "almost", I mean "not yet".)